### PR TITLE
Optimize yearly notebook for faster collection

### DIFF
--- a/yearly runs/yearly.ipynb
+++ b/yearly runs/yearly.ipynb
@@ -4,16 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Rate-Limited Market Cap Filtered Data Collection (Year by Year)\n\n",
-    "This notebook collects financial data for **US stocks with market cap > $1B** with strict rate limiting and saves each year separately.\n\n",
+    "# Rate-Limited Market Cap Filtered Data Collection (Year by Year)\n",
+    "\n",
+    "This notebook collects financial data for **US stocks with market cap > $1B** with strict rate limiting and saves each year separately.\n",
+    "\n",
     "**Key features:**\n",
     "1. **Market cap filter**: Only collects data for stocks with market cap > $1B\n",
     "2. **Rate limiting**: 750 API calls per minute\n",
     "3. **Year-by-year collection**: Each year saved to separate CSV\n",
     "4. **Deduplication**: Ensures only one entry per quarter (Q1-Q4)\n",
     "5. **Enhanced metrics**: Includes book-to-market and earnings yield\n",
-    "6. **Error tracking**: Detailed logs for debugging\n\n",
-    "**Target columns:** `quarter`, `ticker`, `industry`, `sector`, `debt_to_assets`, `mkt_cap`, `stock_price`, `book_to_market`, `earnings_yield`, `mkt_cap_rank`\n\n",
+    "6. **Error tracking**: Detailed logs for debugging\n",
+    "\n",
+    "**Target columns:** `quarter`, `ticker`, `industry`, `sector`, `debt_to_assets`, `mkt_cap`, `stock_price`, `book_to_market`, `earnings_yield`, `mkt_cap_rank`\n",
+    "\n",
     "**Time estimate:** ~70 minutes per year (vs 2.7 hours without filtering)"
    ]
   },
@@ -21,7 +25,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# \u26a0\ufe0f MARKET CAP FILTERED COLLECTION\n\n**This notebook filters for stocks with market cap > $1B**\n\n**Time requirements:**\n- **Per year:** ~70 minutes (with market cap filtering)\n- **All 6 years (2019-2024):** ~7 hours total\n- **API calls:** ~21,000 per year (vs 48,000 without filtering)\n- **Expected companies:** ~1,800 per year (15-20% of all tickers)\n\n**To start with a smaller test:**\n1. Change `MAX_TICKERS = None` to `MAX_TICKERS = 100` in any collection cell\n2. Run one year first to verify everything works\n3. Then change back to `MAX_TICKERS = None` for full collection\n\n---"
+    "# ⚠️ MARKET CAP FILTERED COLLECTION\n",
+    "\n",
+    "**This notebook filters for stocks with market cap > $1B**\n",
+    "\n",
+    "**Time requirements:**\n",
+    "- **Per year:** ~70 minutes (with market cap filtering)\n",
+    "- **All 6 years (2019-2024):** ~7 hours total\n",
+    "- **API calls:** ~21,000 per year (vs 48,000 without filtering)\n",
+    "- **Expected companies:** ~1,800 per year (15-20% of all tickers)\n",
+    "\n",
+    "**To start with a smaller test:**\n",
+    "1. Change `MAX_TICKERS = None` to `MAX_TICKERS = 100` in any collection cell\n",
+    "2. Run one year first to verify everything works\n",
+    "3. Then change back to `MAX_TICKERS = None` for full collection\n",
+    "\n",
+    "---"
    ]
   },
   {
@@ -35,6 +54,7 @@
     "import time\n",
     "from typing import Optional, List, Dict, Any, Tuple\n",
     "from datetime import datetime, timedelta\n",
+    "import threading\n",
     "import json\n",
     "import os\n",
     "\n",
@@ -47,6 +67,7 @@
     "\n",
     "# Session and timer for rate limiting\n",
     "session = requests.Session()\n",
+    "rate_limit_lock = threading.Lock()\n",
     "LAST_API_CALL = 0.0\n",
     "\n",
     "# Market cap threshold (1 billion)\n",
@@ -74,13 +95,14 @@
     "    global LAST_API_CALL, session\n",
     "    try:\n",
     "        params['apikey'] = API\n",
-    "        elapsed = time.time() - LAST_API_CALL\n",
-    "        if elapsed < SECONDS_PER_CALL:\n",
-    "            time.sleep(SECONDS_PER_CALL - elapsed)\n",
+    "        with rate_limit_lock:\n",
+    "            elapsed = time.time() - LAST_API_CALL\n",
+    "            if elapsed < SECONDS_PER_CALL:\n",
+    "                time.sleep(SECONDS_PER_CALL - elapsed)\n",
+    "            LAST_API_CALL = time.time()\n",
     "        response = session.get(url, params=params, timeout=10)\n",
-    "        LAST_API_CALL = time.time()\n",
     "        if response.status_code == 429:\n",
-    "            print('\u26a0\ufe0f  Rate limit hit! Waiting 30 seconds...')\n",
+    "            print('⚠️  Rate limit hit! Waiting 30 seconds...')\n",
     "            time.sleep(30)\n",
     "            return get_json(url, params)\n",
     "        response.raise_for_status()\n",
@@ -128,7 +150,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "def get_bulk_profiles(tickers: List[str]) -> Dict[str, Any]:\n",
     "    \"\"\"Fetch company profiles in bulk.\"\"\"\n",
@@ -154,9 +178,7 @@
     "            df = pd.DataFrame(hist)\n",
     "            caps[symbol] = df['marketCap'].mean()\n",
     "    return caps\n"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
@@ -254,78 +276,81 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def collect_year_data(tickers: List[str], year: int, max_tickers: Optional[int] = None, \n",
-    "                     save_progress: bool = True, progress_interval: int = 100) -> Tuple[pd.DataFrame, List[Dict]]:\n",
-    "    \"\"\"Collect data for multiple tickers for a specific year with strict rate limiting\"\"\"\n",
+    "from concurrent.futures import ThreadPoolExecutor, as_completed\n",
+    "\n",
+    "def collect_year_data(tickers: List[str], year: int, max_tickers: Optional[int] = None,\n",
+    "                     save_progress: bool = True, progress_interval: int = 100,\n",
+    "                     workers: int = 5) -> Tuple[pd.DataFrame, List[Dict]]:\n",
+    "    \"\"\"Collect data for multiple tickers for a specific year using threads.\"\"\"\n",
     "    all_data = []\n",
     "    all_errors = []\n",
     "    successful_tickers = []\n",
     "    failed_tickers = []\n",
     "    skipped_tickers = []\n",
     "    total_api_calls = 0\n",
-    "    \n",
+    "\n",
     "    tickers_to_process = tickers[:max_tickers] if max_tickers else tickers\n",
     "    total_tickers = len(tickers_to_process)\n",
-    "    \n",
-    "    print(f\"\\n{'='*70}\")\n",
+    "\n",
+    "    print(f\"\n",
+    "{'='*70}\")\n",
     "    print(f\"  COLLECTING DATA FOR YEAR {year}\")\n",
     "    print(f\"{'='*70}\")\n",
     "    print(f\"Total tickers to check: {total_tickers}\")\n",
     "    print(f\"Market cap filter: >${MARKET_CAP_THRESHOLD/1e9:.0f}B\")\n",
     "    print(f\"API rate limit: {API_CALLS_PER_MINUTE} calls/minute\")\n",
     "    print(f\"Progress saves: Every {progress_interval} tickers\")\n",
-    "    print(f\"{'='*70}\\n\")\n",
-    "    \n",
+    "    print(f\"{'='*70}\n",
+    "\")\n",
+    "\n",
     "    start_time = time.time()\n",
-    "    last_call_time = time.time()\n",
-    "    \n",
-    "    for i, ticker in enumerate(tickers_to_process):\n",
-    "        # Progress update\n",
-    "        if i > 0 and i % 20 == 0:\n",
-    "            elapsed = time.time() - start_time\n",
-    "            avg_time = elapsed / i\n",
-    "            remaining = (total_tickers - i) * avg_time\n",
-    "            \n",
-    "            print(f\"\\n[Progress: {i}/{total_tickers} ({i/total_tickers*100:.1f}%)]\")\n",
-    "            print(f\"  Time: {elapsed/60:.1f}min elapsed, ~{remaining/60:.1f}min remaining\")\n",
-    "            print(f\"  Success: {len(successful_tickers)}, Failed: {len(failed_tickers)}, Skipped (small cap): {len(skipped_tickers)}\")\n",
-    "            print(f\"  API calls: {total_api_calls} ({total_api_calls/elapsed*60:.0f}/minute avg)\")\n",
-    "            print(f\"  Current batch: \", end=\"\")\n",
-    "        \n",
-    "        # Rate limiting\n",
-    "        time_since_last_call = time.time() - last_call_time\n",
-    "        if time_since_last_call < SECONDS_PER_CALL:\n",
-    "            time.sleep(SECONDS_PER_CALL - time_since_last_call)\n",
-    "        last_call_time = time.time()\n",
-    "        \n",
-    "        # Process ticker\n",
-    "        ticker_data, error_log, api_calls = process_ticker_year(ticker, year)\n",
-    "        total_api_calls += api_calls\n",
-    "        \n",
-    "        if ticker_data is not None and len(ticker_data) > 0:\n",
-    "            all_data.append(ticker_data)\n",
-    "            successful_tickers.append(ticker)\n",
-    "            print(\"\u2713\", end=\"\", flush=True)\n",
-    "        elif any(\"Market cap below threshold\" in err for err in error_log.get(\"errors\", [])):\n",
-    "            skipped_tickers.append(ticker)\n",
-    "            print(\"\u25cb\", end=\"\", flush=True)\n",
-    "        else:\n",
-    "            failed_tickers.append(ticker)\n",
-    "            all_errors.append(error_log)\n",
-    "            print(\"\u2717\", end=\"\", flush=True)\n",
-    "        \n",
-    "        # Save progress periodically\n",
-    "        if save_progress and (i + 1) % progress_interval == 0 and all_data:\n",
-    "            temp_df = pd.concat(all_data, ignore_index=True)\n",
-    "            temp_df['mkt_cap_rank'] = temp_df.groupby('quarter')['mkt_cap'].rank(method='dense', ascending=False).astype(int)\n",
-    "            progress_filename = f\"progress_{year}_tickers_{i+1}.csv\"\n",
-    "            temp_df.to_csv(progress_filename, index=False)\n",
-    "            print(f\"\\n  \ud83d\udcbe Progress saved: {progress_filename} ({len(temp_df)} rows)\")\n",
-    "    \n",
-    "    # Final summary\n",
+    "    progress_lock = threading.Lock()\n",
+    "    profile_cache = {}\n",
+    "    market_cap_cache = {}\n",
+    "    batch_size = 50\n",
+    "    for i in range(0, total_tickers, batch_size):\n",
+    "        batch = tickers_to_process[i:i+batch_size]\n",
+    "        profile_cache.update(get_bulk_profiles(batch))\n",
+    "        market_cap_cache.update(get_bulk_market_caps(batch, year))\n",
+    "\n",
+    "\n",
+    "    def worker(ticker):\n",
+    "        nonlocal total_api_calls\n",
+    "        data, error_log, api_calls = process_ticker_year(ticker, year, profile_cache.get(ticker), market_cap_cache.get(ticker))\n",
+    "        with progress_lock:\n",
+    "            total_api_calls += api_calls\n",
+    "            if data is not None and len(data) > 0:\n",
+    "                all_data.append(data)\n",
+    "                successful_tickers.append(ticker)\n",
+    "                ch = '✓'\n",
+    "            elif any('Market cap below threshold' in err for err in error_log.get('errors', [])):\n",
+    "                skipped_tickers.append(ticker)\n",
+    "                ch = '○'\n",
+    "            else:\n",
+    "                failed_tickers.append(ticker)\n",
+    "                all_errors.append(error_log)\n",
+    "                ch = '✗'\n",
+    "            print(ch, end='', flush=True)\n",
+    "\n",
+    "    with ThreadPoolExecutor(max_workers=workers) as executor:\n",
+    "        futures = {executor.submit(worker, t): t for t in tickers_to_process}\n",
+    "        for i, f in enumerate(as_completed(futures), 1):\n",
+    "            if i % 20 == 0:\n",
+    "                elapsed = time.time() - start_time\n",
+    "                avg_time = elapsed / i\n",
+    "                remaining = (total_tickers - i) * avg_time\n",
+    "                print(f\"\n",
+    "[Progress: {i}/{total_tickers} ({i/total_tickers*100:.1f}%)]\")\n",
+    "                print(f\"  Time: {elapsed/60:.1f}min elapsed, ~{remaining/60:.1f}min remaining\")\n",
+    "                print(f\"  Success: {len(successful_tickers)}, Failed: {len(failed_tickers)}, Skipped (small cap): {len(skipped_tickers)}\")\n",
+    "                print(f\"  API calls: {total_api_calls} ({total_api_calls/elapsed*60:.0f}/minute avg)\")\n",
+    "                print(f\"  Current batch: \", end='')\n",
+    "\n",
     "    total_time = time.time() - start_time\n",
-    "    \n",
-    "    print(f\"\\n\\n{'='*70}\")\n",
+    "\n",
+    "    print(f\"\n",
+    "\n",
+    "{'='*70}\")\n",
     "    print(f\"  YEAR {year} COLLECTION COMPLETE\")\n",
     "    print(f\"{'='*70}\")\n",
     "    print(f\"Total time: {total_time/60:.1f} minutes ({total_time/3600:.2f} hours)\")\n",
@@ -333,49 +358,40 @@
     "    print(f\"Failed: {len(failed_tickers)} tickers\")\n",
     "    print(f\"Skipped (small cap): {len(skipped_tickers)} tickers\")\n",
     "    print(f\"Total API calls: {total_api_calls:,} ({total_api_calls/total_time*60:.0f}/minute avg)\")\n",
-    "    \n",
+    "\n",
     "    if len(all_data) == 0:\n",
-    "        print(\"\\n\u26a0\ufe0f  No data collected!\")\n",
-    "        return pd.DataFrame(columns=[\"quarter\", \"ticker\", \"industry\", \"sector\", \n",
-    "                                    \"debt_to_assets\", \"mkt_cap\", \"stock_price\", \n",
-    "                                    \"book_to_market\", \"earnings_yield\", \"mkt_cap_rank\"]), all_errors\n",
-    "    \n",
-    "    # Combine all data\n",
+    "        print(\"\n",
+    "⚠️  No data collected!\")\n",
+    "        return pd.DataFrame(columns=['quarter','ticker','industry','sector','debt_to_assets','mkt_cap','stock_price','book_to_market','earnings_yield','mkt_cap_rank']), all_errors\n",
+    "\n",
     "    final_df = pd.concat(all_data, ignore_index=True)\n",
-    "    \n",
-    "    # Final deduplication - ensure only one entry per ticker-quarter\n",
-    "    final_df = final_df.sort_values(['ticker', 'quarter']).drop_duplicates(['ticker', 'quarter'], keep='last')\n",
-    "    \n",
-    "    # Add market cap ranking\n",
+    "    final_df = final_df.sort_values(['ticker','quarter']).drop_duplicates(['ticker','quarter'], keep='last')\n",
     "    final_df['mkt_cap_rank'] = final_df.groupby('quarter')['mkt_cap'].rank(method='dense', ascending=False).astype(int)\n",
-    "    \n",
-    "    # Sort by ticker and quarter\n",
-    "    final_df = final_df.sort_values(['ticker', 'quarter']).reset_index(drop=True)\n",
-    "    \n",
-    "    print(f\"\\n\ud83d\udcca Final dataset: {len(final_df)} rows, {final_df['ticker'].nunique()} tickers\")\n",
+    "    final_df = final_df.sort_values(['ticker','quarter']).reset_index(drop=True)\n",
+    "\n",
+    "    print(f\"\n",
+    "📊 Final dataset: {len(final_df)} rows, {final_df['ticker'].nunique()} tickers\")\n",
     "    print(f\"   Quarters: {sorted(final_df['quarter'].unique())}\")\n",
-    "    \n",
-    "    # Verify quarter coverage\n",
+    "\n",
     "    expected_quarters = {f\"{year}Q1\", f\"{year}Q2\", f\"{year}Q3\", f\"{year}Q4\"}\n",
     "    actual_quarters = set(final_df['quarter'].astype(str).unique())\n",
     "    missing_quarters = expected_quarters - actual_quarters\n",
     "    if missing_quarters:\n",
-    "        print(f\"   \u26a0\ufe0f  Missing quarters: {sorted(missing_quarters)}\")\n",
-    "    \n",
-    "    # Save error log\n",
+    "        print(f\"   ⚠️  Missing quarters: {sorted(missing_quarters)}\")\n",
+    "\n",
     "    if all_errors:\n",
     "        error_filename = f\"errors_{year}.json\"\n",
     "        with open(error_filename, 'w') as f:\n",
     "            json.dump(all_errors, f, indent=2, default=str)\n",
-    "        print(f\"\\n\ud83d\udcdd Error log saved: {error_filename} ({len(all_errors)} errors)\")\n",
-    "    \n",
-    "    # Clean up progress files\n",
+    "        print(f\"\n",
+    "📝 Error log saved: {error_filename} ({len(all_errors)} errors)\")\n",
+    "\n",
     "    if save_progress:\n",
     "        for progress_file in [f for f in os.listdir('.') if f.startswith(f'progress_{year}_')]:\n",
     "            os.remove(progress_file)\n",
-    "        print(f\"\ud83e\uddf9 Cleaned up progress files\")\n",
-    "    \n",
-    "    return final_df, all_errors"
+    "        print(f\"🧹 Cleaned up progress files\")\n",
+    "\n",
+    "    return final_df, all_errors\n"
    ]
   },
   {
@@ -391,32 +407,51 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get list of US tickers\n",
-    "print(\"Fetching ticker list...\")\n",
-    "tickers_data = get_json(\"https://financialmodelingprep.com/api/v3/stock/list\")\n",
+    "# Get list of US tickers for a specific year\n",
     "\n",
-    "if tickers_data:\n",
-    "    # Filter for US exchanges and remove penny stocks\n",
-    "    us_tickers = [\n",
-    "        d[\"symbol\"] for d in tickers_data \n",
-    "        if d[\"exchangeShortName\"] in [\"NYSE\", \"NASDAQ\"] \n",
-    "        and (d.get(\"price\") is not None and d.get(\"price\", 0) > 5)\n",
-    "        and len(d[\"symbol\"]) <= 5\n",
-    "        and \".\" not in d[\"symbol\"]\n",
-    "    ]\n",
-    "    \n",
-    "    print(f\"\u2705 Found {len(us_tickers)} US tickers\")\n",
-    "    print(f\"   Sample: {us_tickers[:10]}\")\n",
-    "    \n",
-    "    # Estimate how many will be large cap\n",
-    "    estimated_large_cap = int(len(us_tickers) * 0.15)\n",
-    "    print(f\"\\n\ud83d\udcca Estimates:\")\n",
-    "    print(f\"   Expected large cap (>$1B): ~{estimated_large_cap} stocks\")\n",
-    "    print(f\"   Estimated API calls per year: ~{len(us_tickers) + estimated_large_cap * 5:,}\")\n",
-    "    print(f\"   Estimated time per year: ~{(len(us_tickers) + estimated_large_cap * 5) / API_CALLS_PER_MINUTE:.0f} minutes\")\n",
-    "else:\n",
-    "    print(\"\u274c Failed to fetch ticker list. Using sample tickers.\")\n",
-    "    us_tickers = [\"AAPL\", \"MSFT\", \"GOOGL\", \"AMZN\", \"TSLA\", \"META\", \"NVDA\", \"JPM\", \"JNJ\", \"V\"]"
+    "def _fetch_constituents(exchange: str, date: str) -> List[str]:\n",
+    "    \"\"\"Retrieve all tickers for an exchange on a given date handling pagination.\"\"\"\n",
+    "    tickers = []\n",
+    "    page = 0\n",
+    "    while True:\n",
+    "        batch = get_json(\n",
+    "            f'https://financialmodelingprep.com/api/v3/historical/{exchange}_constituent',\n",
+    "            {\"date\": date, \"page\": page}\n",
+    "        ) or []\n",
+    "        if not batch:\n",
+    "            break\n",
+    "        tickers.extend([d.get('symbol') for d in batch])\n",
+    "        page += 1\n",
+    "    return tickers\n",
+    "\n",
+    "def get_tickers_for_year(year: int) -> List[str]:\n",
+    "    \"\"\"Fetch tickers as of the end of the previous year.\"\"\"\n",
+    "    date = f'{year-1}-12-31'\n",
+    "    nasdaq = _fetch_constituents('nasdaq', date)\n",
+    "    nyse = _fetch_constituents('nyse', date)\n",
+    "    tickers = [t for t in nasdaq + nyse if t]\n",
+    "    if not tickers:\n",
+    "        tickers_data = get_json('https://financialmodelingprep.com/api/v3/stock/list') or []\n",
+    "        tickers = [\n",
+    "            d['symbol']\n",
+    "            for d in tickers_data\n",
+    "            if d.get('exchangeShortName') in ['NYSE', 'NASDAQ']\n",
+    "            and (d.get('price') is not None and d.get('price', 0) > 5)\n",
+    "            and len(d['symbol']) <= 5\n",
+    "            and '.' not in d['symbol']\n",
+    "        ]\n",
+    "    return sorted(set(tickers))\n",
+    "\n",
+    "us_tickers = get_tickers_for_year(2024)\n",
+    "print(f\"✅ Found {len(us_tickers)} tickers for 2024\")\n",
+    "print(f\"   Sample: {us_tickers[:10]}\")\n",
+    "\n",
+    "estimated_large_cap = int(len(us_tickers) * 0.15)\n",
+    "print(\"\n",
+    "📊 Estimates:\")\n",
+    "print(f\"   Expected large cap (>$1B): ~{estimated_large_cap} stocks\")\n",
+    "print(f\"   Estimated API calls per year: ~{len(us_tickers) + estimated_large_cap * 5:,}\")\n",
+    "print(f\"   Estimated time per year: ~{(len(us_tickers) + estimated_large_cap * 5) / API_CALLS_PER_MINUTE:.0f} minutes\")\n"
    ]
   },
   {
@@ -442,14 +477,14 @@
     "print(f\"\\nTest completed in {test_time:.2f} seconds with {test_api_calls} API calls\")\n",
     "\n",
     "if test_data is not None:\n",
-    "    print(\"\\n\u2705 Test successful!\")\n",
+    "    print(\"\\n✅ Test successful!\")\n",
     "    print(test_data)\n",
     "    print(f\"\\nQuarters found: {sorted(test_data['quarter'].unique())}\")\n",
     "    print(f\"\\nSample metrics:\")\n",
     "    print(f\"  Book-to-Market: {test_data['book_to_market'].mean():.3f}\")\n",
     "    print(f\"  Earnings Yield: {test_data['earnings_yield'].mean():.3f}\")\n",
     "else:\n",
-    "    print(\"\\n\u274c Test failed!\")\n",
+    "    print(\"\\n❌ Test failed!\")\n",
     "    print(\"Errors:\", test_errors)"
    ]
   },
@@ -477,14 +512,15 @@
     "# Collect 2024 data\n",
     "YEAR = 2024\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
-    "data_2024, errors_2024 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n\n",
+    "data_2024, errors_2024 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "\n",
     "if len(data_2024) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2024.to_csv(filename, index=False)\n",
-    "    print(f\"\\n\u2705 Data saved to '{filename}'\")\n",
+    "    print(f\"\\n✅ Data saved to '{filename}'\")\n",
     "    \n",
     "    # Show summary statistics\n",
-    "    print(f\"\\n\ud83d\udcc8 Summary Statistics:\")\n",
+    "    print(f\"\\n📈 Summary Statistics:\")\n",
     "    print(f\"   Debt/Assets - Mean: {data_2024['debt_to_assets'].mean():.3f}, Median: {data_2024['debt_to_assets'].median():.3f}\")\n",
     "    print(f\"   Book/Market - Mean: {data_2024['book_to_market'].mean():.3f}, Median: {data_2024['book_to_market'].median():.3f}\")\n",
     "    print(f\"   Earnings Yield - Mean: {data_2024['earnings_yield'].mean():.3f}, Median: {data_2024['earnings_yield'].median():.3f}\")\n",
@@ -493,13 +529,13 @@
     "    latest_quarter = data_2024['quarter'].max()\n",
     "    latest_data = data_2024[data_2024['quarter'] == latest_quarter]\n",
     "    if len(latest_data) > 0:\n",
-    "        print(f\"\\n\ud83c\udfc6 Top 10 companies by market cap ({latest_quarter}):\")\n",
+    "        print(f\"\\n🏆 Top 10 companies by market cap ({latest_quarter}):\")\n",
     "        top_10 = latest_data.nsmallest(10, 'mkt_cap_rank')[['ticker', 'mkt_cap_rank', 'mkt_cap', 'book_to_market', 'earnings_yield', 'industry']]\n",
     "        top_10['mkt_cap'] = top_10['mkt_cap'].apply(lambda x: f\"${x/1e9:.1f}B\")\n",
     "        print(top_10.to_string(index=False))\n",
     "    \n",
     "    # Show available quarters\n",
-    "    print(f\"\\n\ud83d\udcc5 Available quarters for 2024: {sorted(data_2024['quarter'].unique())}\")"
+    "    print(f\"\\n📅 Available quarters for 2024: {sorted(data_2024['quarter'].unique())}\")"
    ]
   },
   {
@@ -519,15 +555,15 @@
     "YEAR = 2023\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2023, errors_2023 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2023, errors_2023 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2023) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2023.to_csv(filename, index=False)\n",
-    "    print(f\"\\n\u2705 Data saved to '{filename}'\")\n",
+    "    print(f\"\\n✅ Data saved to '{filename}'\")\n",
     "    \n",
     "    # Show summary statistics\n",
-    "    print(f\"\\n\ud83d\udcc8 Summary Statistics:\")\n",
+    "    print(f\"\\n📈 Summary Statistics:\")\n",
     "    print(f\"   Debt/Assets - Mean: {data_2023['debt_to_assets'].mean():.3f}, Median: {data_2023['debt_to_assets'].median():.3f}\")\n",
     "    print(f\"   Book/Market - Mean: {data_2023['book_to_market'].mean():.3f}, Median: {data_2023['book_to_market'].median():.3f}\")\n",
     "    print(f\"   Earnings Yield - Mean: {data_2023['earnings_yield'].mean():.3f}, Median: {data_2023['earnings_yield'].median():.3f}\")\n",
@@ -535,7 +571,7 @@
     "    # Show top companies\n",
     "    q4_data = data_2023[data_2023['quarter'] == f'{YEAR}Q4']\n",
     "    if len(q4_data) > 0:\n",
-    "        print(f\"\\n\ud83c\udfc6 Top 10 companies by market cap (Q4 {YEAR}):\")\n",
+    "        print(f\"\\n🏆 Top 10 companies by market cap (Q4 {YEAR}):\")\n",
     "        top_10 = q4_data.nsmallest(10, 'mkt_cap_rank')[['ticker', 'mkt_cap_rank', 'mkt_cap', 'book_to_market', 'earnings_yield', 'industry']]\n",
     "        top_10['mkt_cap'] = top_10['mkt_cap'].apply(lambda x: f\"${x/1e9:.1f}B\")\n",
     "        print(top_10.to_string(index=False))"
@@ -558,12 +594,12 @@
     "YEAR = 2022\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2022, errors_2022 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2022, errors_2022 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2022) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2022.to_csv(filename, index=False)\n",
-    "    print(f\"\\n\u2705 Data saved to '{filename}'\")"
+    "    print(f\"\\n✅ Data saved to '{filename}'\")"
    ]
   },
   {
@@ -583,12 +619,12 @@
     "YEAR = 2021\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2021, errors_2021 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2021, errors_2021 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2021) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2021.to_csv(filename, index=False)\n",
-    "    print(f\"\\n\u2705 Data saved to '{filename}'\")"
+    "    print(f\"\\n✅ Data saved to '{filename}'\")"
    ]
   },
   {
@@ -608,12 +644,12 @@
     "YEAR = 2020\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2020, errors_2020 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2020, errors_2020 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2020) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2020.to_csv(filename, index=False)\n",
-    "    print(f\"\\n\u2705 Data saved to '{filename}'\")"
+    "    print(f\"\\n✅ Data saved to '{filename}'\")"
    ]
   },
   {
@@ -633,12 +669,12 @@
     "YEAR = 2019\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2019, errors_2019 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2019, errors_2019 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2019) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2019.to_csv(filename, index=False)\n",
-    "    print(f\"\\n\u2705 Data saved to '{filename}'\")"
+    "    print(f\"\\n✅ Data saved to '{filename}'\")"
    ]
   },
   {
@@ -658,12 +694,13 @@
     "YEAR = 2018\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2018, errors_2018 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2018, errors_2018 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2018) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2018.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -694,12 +731,13 @@
     "YEAR = 2017\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2017, errors_2017 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2017, errors_2017 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2017) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2017.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -730,12 +768,13 @@
     "YEAR = 2016\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2016, errors_2016 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2016, errors_2016 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2016) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2016.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -766,12 +805,13 @@
     "YEAR = 2015\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2015, errors_2015 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2015, errors_2015 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2015) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2015.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -802,12 +842,13 @@
     "YEAR = 2014\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2014, errors_2014 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2014, errors_2014 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2014) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2014.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -838,12 +879,13 @@
     "YEAR = 2013\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2013, errors_2013 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2013, errors_2013 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2013) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2013.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -874,12 +916,13 @@
     "YEAR = 2012\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2012, errors_2012 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2012, errors_2012 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2012) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2012.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -910,12 +953,13 @@
     "YEAR = 2011\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2011, errors_2011 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2011, errors_2011 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2011) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2011.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -946,12 +990,13 @@
     "YEAR = 2010\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2010, errors_2010 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2010, errors_2010 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2010) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2010.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -982,12 +1027,13 @@
     "YEAR = 2009\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2009, errors_2009 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2009, errors_2009 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2009) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2009.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1018,12 +1064,13 @@
     "YEAR = 2008\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2008, errors_2008 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2008, errors_2008 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2008) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2008.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1054,12 +1101,13 @@
     "YEAR = 2007\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2007, errors_2007 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2007, errors_2007 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2007) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2007.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1090,12 +1138,13 @@
     "YEAR = 2006\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2006, errors_2006 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2006, errors_2006 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2006) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2006.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1126,12 +1175,13 @@
     "YEAR = 2005\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2005, errors_2005 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2005, errors_2005 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2005) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2005.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1162,12 +1212,13 @@
     "YEAR = 2004\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2004, errors_2004 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2004, errors_2004 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2004) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2004.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1198,12 +1249,13 @@
     "YEAR = 2003\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2003, errors_2003 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2003, errors_2003 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2003) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2003.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1234,12 +1286,13 @@
     "YEAR = 2002\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2002, errors_2002 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2002, errors_2002 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2002) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2002.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1270,12 +1323,13 @@
     "YEAR = 2001\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2001, errors_2001 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2001, errors_2001 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2001) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2001.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1306,12 +1360,13 @@
     "YEAR = 2000\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_2000, errors_2000 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_2000, errors_2000 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_2000) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_2000.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1342,12 +1397,13 @@
     "YEAR = 1999\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_1999, errors_1999 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_1999, errors_1999 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_1999) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_1999.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1378,12 +1434,13 @@
     "YEAR = 1998\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_1998, errors_1998 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_1998, errors_1998 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_1998) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_1998.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1414,12 +1471,13 @@
     "YEAR = 1997\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_1997, errors_1997 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_1997, errors_1997 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_1997) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_1997.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1450,12 +1508,13 @@
     "YEAR = 1996\n",
     "MAX_TICKERS = None  # Collect ALL US tickers (~12,000)\n",
     "\n",
-    "data_1996, errors_1996 = collect_year_data(us_tickers, year=YEAR, max_tickers=MAX_TICKERS)\n",
+    "data_1996, errors_1996 = collect_year_data(get_tickers_for_year(YEAR), year=YEAR, max_tickers=MAX_TICKERS)\n",
     "\n",
     "if len(data_1996) > 0:\n",
     "    filename = f\"stock_data_{YEAR}.csv\"\n",
     "    data_1996.to_csv(filename, index=False)\n",
-    "    print(f\n\u2705 Data saved to '{filename}')\n"
+    "    print(f\n",
+    "✅ Data saved to '{filename}')\n"
    ]
   },
   {
@@ -1485,7 +1544,7 @@
     "# Review what we've collected\n",
     "import glob\n",
     "\n",
-    "print(\"\ud83d\udcc1 Available data files:\")\n",
+    "print(\"📁 Available data files:\")\n",
     "data_files = sorted(glob.glob(\"stock_data_*.csv\"))\n",
     "\n",
     "total_rows = 0\n",
@@ -1496,9 +1555,9 @@
     "    # Check for duplicates\n",
     "    duplicates = df.groupby(['ticker', 'quarter']).size()\n",
     "    if (duplicates > 1).any():\n",
-    "        print(f\"    \u26a0\ufe0f  Found {(duplicates > 1).sum()} duplicate ticker-quarter combinations\")\n",
+    "        print(f\"    ⚠️  Found {(duplicates > 1).sum()} duplicate ticker-quarter combinations\")\n",
     "\n",
-    "print(f\"\\n\ud83d\udcca Total: {total_rows:,} rows across {len(data_files)} files\")"
+    "print(f\"\\n📊 Total: {total_rows:,} rows across {len(data_files)} files\")"
    ]
   },
   {
@@ -1511,7 +1570,7 @@
     "error_files = sorted(glob.glob(\"errors_*.json\"))\n",
     "\n",
     "if error_files:\n",
-    "    print(\"\ud83d\udcdd Error analysis:\")\n",
+    "    print(\"📝 Error analysis:\")\n",
     "    \n",
     "    for error_file in error_files:\n",
     "        with open(error_file, 'r') as f:\n",
@@ -1554,9 +1613,9 @@
     "        df = pd.read_csv(filename)\n",
     "        df['quarter'] = pd.PeriodIndex(df['quarter'], freq='Q')\n",
     "        all_data.append(df)\n",
-    "        print(f\"\u2713 Loaded {year}: {len(df)} rows\")\n",
+    "        print(f\"✓ Loaded {year}: {len(df)} rows\")\n",
     "    else:\n",
-    "        print(f\"\u2717 {filename} not found\")\n",
+    "        print(f\"✗ {filename} not found\")\n",
     "\n",
     "if all_data:\n",
     "    combined = pd.concat(all_data, ignore_index=True)\n",
@@ -1569,13 +1628,13 @@
     "    \n",
     "    combined.to_csv(\"stock_data_combined_6years.csv\", index=False)\n",
     "    \n",
-    "    print(f\"\\n\u2705 Combined dataset saved!\")\n",
+    "    print(f\"\\n✅ Combined dataset saved!\")\n",
     "    print(f\"   Total: {len(combined):,} rows\")\n",
     "    print(f\"   Tickers: {combined['ticker'].nunique()}\")\n",
     "    print(f\"   Period: {combined['quarter'].min()} to {combined['quarter'].max()}\")\n",
     "    \n",
     "    # Show metric distributions\n",
-    "    print(f\"\\n\ud83d\udcca Metric distributions:\")\n",
+    "    print(f\"\\n📊 Metric distributions:\")\n",
     "    print(f\"   Debt/Assets: {combined['debt_to_assets'].describe()[[\"mean\", \"50%\", \"std\"]].round(3).to_dict()}\")\n",
     "    print(f\"   Book/Market: {combined['book_to_market'].describe()[[\"mean\", \"50%\", \"std\"]].round(3).to_dict()}\")\n",
     "    print(f\"   Earnings Yield: {combined['earnings_yield'].describe()[[\"mean\", \"50%\", \"std\"]].round(3).to_dict()}\")"


### PR DESCRIPTION
## Summary
- add rate limit lock to support concurrency
- fetch tickers for each year based on prior-year constituents
- parallelize yearly collection using `ThreadPoolExecutor`
- prefetch profiles and market caps in bulk
- update yearly cells to use year-specific ticker lists
- fix historical ticker retrieval to handle pagination

## Testing
- `pytest -q`
- `python - <<'PY'
import nbformat
nb = nbformat.read('yearly runs/yearly.ipynb', as_version=4)
nbformat.validate(nb)
print('Notebook valid')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684a1c91f858832a9e3c0bd4c676d0e2