### PR TITLE
Improve ticker retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Stocks Data Collection
 
 This repository contains a notebook for downloading historical stock fundamentals.
+Retrieving the ticker list now uses a single API call and should take only a few seconds.
 
 ## API Key
 

--- a/yearly runs/yearly.ipynb
+++ b/yearly runs/yearly.ipynb
@@ -441,24 +441,16 @@
     "def get_tickers_for_year(year: int) -> List[str]:\n",
     "    \"\"\"Fast retrieval of tickers with market cap above threshold for the given year.\"\"\"\n",
     "    date = f'{year-1}-12-31'\n",
-    "    tickers: List[str] = []\n",
-    "    page = 0\n",
-    "    while True:\n",
-    "        data = get_json(\n",
-    "            'https://financialmodelingprep.com/api/v3/stock-screener',\n",
-    "            {\n",
-    "                'exchange': 'NASDAQ,NYSE',\n",
-    "                'marketCapMoreThan': int(MARKET_CAP_THRESHOLD),\n",
-    "                'date': date,\n",
-    "                'limit': 1000,\n",
-    "                'page': page,\n",
-    "            },\n",
-    "        ) or []\n",
-    "        if not data:\n",
-    "            break\n",
-    "        tickers.extend([d.get('symbol') for d in data if d.get('symbol')])\n",
-    "        page += 1\n",
-    "    return sorted(set(tickers))\n",
+    "    data = get_json(\n",
+    "        'https://financialmodelingprep.com/api/v3/stock-screener',\n",
+    "        {\n",
+    "            'exchange': 'NASDAQ,NYSE',\n",
+    "            'marketCapMoreThan': int(MARKET_CAP_THRESHOLD),\n",
+    "            'date': date,\n",
+    "            'limit': 100000,\n",
+    "        },\n",
+    "    ) or []\n",
+    "    return sorted({d['symbol'] for d in data if d.get('symbol')})\n",
     "\n",
     "us_tickers = get_tickers_for_year(2024)\n",
     "print(f'✅ Found {len(us_tickers)} tickers for 2024')\n",
@@ -469,6 +461,13 @@
     "print(f'   Expected large cap (>$1B): ~{estimated_large_cap} stocks')\n",
     "print(f'   Estimated API calls per year: ~{len(us_tickers) + estimated_large_cap * 5:,}')\n",
     "print(f'   Estimated time per year: ~{(len(us_tickers) + estimated_large_cap * 5) / API_CALLS_PER_MINUTE:.0f} minutes')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ticker retrieval now uses a single API call and should complete in only a few seconds."
    ]
   },
   {


### PR DESCRIPTION
## Summary
- avoid `page` loop by getting all tickers in one request
- document faster ticker collection in README and notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba23b0ad0832a8e51dad68b87a699